### PR TITLE
Initial implementation of SimDevice support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@wpilib/node-wpilib-ws": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.0.5.tgz",
-      "integrity": "sha512-x+RGaXt+syJ1a4nE29COhr5VRAmR9JAd3RzTWqtvlfBVu4LjgyWQFe82H5InDErzIvoaI3vg2bFdeP3VFldHaw==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@wpilib/node-wpilib-ws/-/node-wpilib-ws-0.0.6.tgz",
+      "integrity": "sha512-2X/9/D/eqkjSj98e3xlK/6SQwTjiN/RVWo5y3fkVZ3FaXC5WI+Gl1+HWgzBJnjEPqqoeyfqKp+aMKDlMCsKZfw==",
       "requires": {
         "strict-event-emitter-types": "^2.0.0",
         "ws": "^7.3.1"
@@ -31,9 +31,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bb-frc-workshops/wpilib-ws-robot#readme",
   "dependencies": {
-    "@wpilib/node-wpilib-ws": "0.0.5"
+    "@wpilib/node-wpilib-ws": "0.0.6"
   },
   "files": [
     "dist/**/*"
@@ -32,5 +32,8 @@
   "devDependencies": {
     "@types/node": "^14.6.0",
     "typescript": "^4.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/src/examples/debug-accelerometer.ts
+++ b/src/examples/debug-accelerometer.ts
@@ -1,0 +1,45 @@
+import SimDevice, { FieldDirection } from "../sim-device";
+
+export default class SimAccelerometer extends SimDevice {
+    private _sensitivity: number = 2;
+
+    constructor() {
+        super("BuiltInAccelerometer");
+
+        this.registerField("accelX", FieldDirection.BIDIR, 0); // fieldIdent: <>accelX
+        this.registerField("accelY", FieldDirection.BIDIR, 0); // fieldIdent: <>accelY
+        this.registerField("accelZ", FieldDirection.BIDIR, 0); // fieldIdent: <>accelZ
+        this.registerField("sensitivity", FieldDirection.OUTPUT_FROM_ROBOT_CODE, 2); // fieldIdent: <sensitivity
+    }
+
+    public set x(value: number) {
+        this.setValue("accelX", value);
+    }
+
+    public get x(): number {
+        return this.getValue("accelX");
+    }
+
+    public set y(value: number) {
+        this.setValue("accelY", value);
+    }
+
+    public get y(): number {
+        return this.getValue("accelY");
+    }
+
+    public set z(value: number) {
+        this.setValue("accelZ", value);
+    }
+
+    public get z(): number {
+        return this.getValue("accelZ");
+    }
+
+    _onSetValue(field: string, value: any) {
+        if (field === "sensitivity") {
+            this._sensitivity = value;
+            console.log("Setting sensitivity: ", value);
+        }
+    }
+}

--- a/src/examples/debug-client.ts
+++ b/src/examples/debug-client.ts
@@ -1,5 +1,5 @@
 import WPILibWSRobotEndpoint from "../wpilib-ws-robot-endpoint";
-import DebugRobot from "../debug-robot";
+import DebugRobot from "./debug-robot";
 
 const robot: DebugRobot = new DebugRobot();
 

--- a/src/examples/debug-robot.ts
+++ b/src/examples/debug-robot.ts
@@ -1,6 +1,37 @@
-import WPILibWSRobotBase, { DigitalChannelMode } from "./robot-base";
+import WPILibWSRobotBase, { DigitalChannelMode } from "../robot-base";
+import SimAccelerometer from "./debug-accelerometer";
 
 export default class DebugRobot extends WPILibWSRobotBase {
+    private _simAccel: SimAccelerometer = new SimAccelerometer();
+
+    constructor() {
+        super();
+
+        this.registerSimDevice(this._simAccel);
+
+        let delta: number = 0.1;
+        let accelVal: number = -2;
+        let count = 0;
+        setInterval(() => {
+            this._simAccel.x = accelVal;
+            this._simAccel.y = Math.sin(count) * 2;
+            this._simAccel.z = Math.cos(count) * 2;
+
+            accelVal += delta;
+            if (accelVal > 2) {
+                accelVal = 2;
+                delta = -delta;
+            }
+
+            if (accelVal < -2) {
+                accelVal = -2;
+                delta = -delta;
+            }
+
+            count++;
+        }, 100);
+    }
+
     public readyP(): Promise<void> {
         return Promise.resolve();
     }

--- a/src/examples/debug-server.ts
+++ b/src/examples/debug-server.ts
@@ -1,5 +1,5 @@
 import WPILibWSRobotEndpoint from "../wpilib-ws-robot-endpoint";
-import DebugRobot from "../debug-robot";
+import DebugRobot from "./debug-robot";
 
 const robot: DebugRobot = new DebugRobot();
 

--- a/src/robot-base.ts
+++ b/src/robot-base.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import SimDevice from "./sim-device";
 
 export enum DigitalChannelMode {
     INPUT,
@@ -12,9 +13,45 @@ export default abstract class WPILibWSRobotBase extends EventEmitter {
     // Identifying information
     public abstract get descriptor(): string;
 
+    // List of SimDevices supported by this robot
+    protected _simDevices: Map<string, SimDevice> = new Map<string, SimDevice>();
+
     // System level information
     public getBatteryPercentage(): number {
         return 0.0;
+    }
+
+    /**
+     * Register a new SimDevice on this robot
+     * @param deviceName
+     * @param deviceChannel
+     * @param device
+     */
+    protected registerSimDevice(device: SimDevice) {
+        const deviceIdent = device.name + (device.channel !== null ? `[${device.channel}]` : "");
+        this._simDevices.set(deviceIdent, device);
+    }
+
+    /**
+     * Get a specific registered SimDevice
+     * @param deviceName
+     * @param deviceChannel
+     */
+    public getSimDevice(deviceName: string, deviceChannel: number | null): SimDevice {
+        const deviceIdent = deviceName + (deviceChannel !== null ? `[${deviceChannel}]` : "");
+        return this._simDevices.get(deviceIdent);
+    }
+
+    /**
+     * Get a list of all registered SimDevice-s
+     */
+    public getAllSimDevices(): SimDevice[] {
+        const devices: SimDevice[] = [];
+        this._simDevices.forEach(device => {
+            devices.push(device);
+        });
+
+        return devices;
     }
 
     public abstract setDigitalChannelMode(channel: number, mode: DigitalChannelMode): void;

--- a/src/sim-device.ts
+++ b/src/sim-device.ts
@@ -39,7 +39,7 @@ function fieldWithDirectionPrefix(field: string, dir: FieldDirection): string {
     return (dirPrefix(dir) + field);
 }
 
-interface FieldNameAndDirection {
+export interface FieldNameAndDirection {
     field: string;
     direction: FieldDirection;
 }
@@ -48,7 +48,7 @@ interface FieldNameAndDirection {
  * Given a field name or identifier string, return the field name and direction
  * @param str
  */
-function fieldNameAndDirection(str: string): FieldNameAndDirection {
+export function fieldNameAndDirection(str: string): FieldNameAndDirection {
     if (str.indexOf("<>") === 0) {
         return {
             field: str.substr(2),

--- a/src/sim-device.ts
+++ b/src/sim-device.ts
@@ -1,0 +1,188 @@
+/**
+ * Field NAME: String used to identify a SimDevice field e.g. `accelerationX`, `accelerationY`
+ * Field IDENTIFIER: String which consists of the Field NAME, prefixed with a direction indicator.
+ *
+ * The Field NAME is the "friendly" identifier for a SimDevice field, while the Field IDENTIFIER
+ * is the string that is used in the WebSocket messages
+ */
+
+export enum FieldDirection {
+    INPUT_TO_ROBOT_CODE,    // Values that should only be written by the simulation side
+    OUTPUT_FROM_ROBOT_CODE, // Values that should only be written by the robot code
+    BIDIR,                  // Values that can be written to by either side
+    UNK                     // Unknown Direction. Used to identify an un-prefixed field identifier
+}
+
+/**
+ * Get the appropriate prefix for a field identifier
+ * @param dir Data flow direction
+ */
+function dirPrefix(dir: FieldDirection): string {
+    switch (dir) {
+        case FieldDirection.INPUT_TO_ROBOT_CODE:
+            return ">";
+        case FieldDirection.OUTPUT_FROM_ROBOT_CODE:
+            return "<";
+        case FieldDirection.BIDIR:
+            return "<>";
+        case FieldDirection.UNK:
+            return "";
+    }
+}
+
+/**
+ * Append the appropriate direction prefix to a field name
+ * @param field
+ * @param dir
+ */
+function fieldWithDirectionPrefix(field: string, dir: FieldDirection): string {
+    return (dirPrefix(dir) + field);
+}
+
+interface FieldNameAndDirection {
+    field: string;
+    direction: FieldDirection;
+}
+
+/**
+ * Given a field name or identifier string, return the field name and direction
+ * @param str
+ */
+function fieldNameAndDirection(str: string): FieldNameAndDirection {
+    if (str.indexOf("<>") === 0) {
+        return {
+            field: str.substr(2),
+            direction: FieldDirection.BIDIR
+        };
+    }
+
+    if (str.indexOf("<") === 0) {
+        return {
+            field: str.substr(1),
+            direction: FieldDirection.OUTPUT_FROM_ROBOT_CODE
+        };
+    }
+
+    if (str.indexOf(">") === 0) {
+        return {
+            field: str.substr(1),
+            direction: FieldDirection.INPUT_TO_ROBOT_CODE
+        };
+    }
+
+    return {
+        field: str,
+        direction: FieldDirection.UNK
+    };
+}
+
+/**
+ * Base class that represents a simulated complex device
+ */
+export default class SimDevice {
+    private _fieldNameToIdent: Map<string, string> = new Map<string, string>();
+    private _fields: Map<string, any> = new Map<string, any>();
+    private _deviceName: string;
+    private _deviceChannel: number | null = null;
+
+    /**
+     * Construct a new SimDevice
+     * @param name
+     * @param channel Channel number or null if this is meant to be a singleton device
+     */
+    constructor(name: string, channel?: number) {
+        this._deviceName = name;
+        if (channel !== undefined ) {
+            this._deviceChannel = channel;
+        }
+    }
+
+    public get name(): string {
+        return this._deviceName;
+    }
+
+    public get channel(): number | null {
+        return this._deviceChannel;
+    }
+
+    /**
+     * Register a field with the SimDevice
+     *
+     * Note: SimDevices on the wpilib side only use OUTPUT_FROM_ROBOT_CODE or BIDIR
+     * @param field Name of this field (without direction prefixes)
+     * @param readonly If set to true, indicates that the simulation side code should NOT write to this field
+     * @param defaultValue
+     */
+    public registerField(field: string, direction : FieldDirection, defaultValue: any) {
+        const fieldIdent: string = fieldWithDirectionPrefix(field, direction);
+
+        if (this._fieldNameToIdent.has(field)) {
+            throw new Error(`Duplicate SimDevice field: "${field}"`);
+        }
+
+        this._fieldNameToIdent.set(field, fieldIdent);
+        this._fields.set(fieldIdent, defaultValue);
+    }
+
+    /**
+     * Get the currently stored value of a field
+     *
+     * The fieldNameOrIdent parameter can be either a field name (without directionality prefix),
+     * or a field identifier (which includes the prefix)
+     * @param fieldNameOrIdent Field name or identifier
+     */
+    public getValue(fieldNameOrIdent: string): any {
+        const fieldNameAndDir = fieldNameAndDirection(fieldNameOrIdent);
+
+        if (this._fieldNameToIdent.has(fieldNameAndDir.field)) {
+            return this._fields.get(this._fieldNameToIdent.get(fieldNameAndDir.field));
+        }
+        return undefined;
+    }
+
+    /**
+     * Set a field to a specified value
+     *
+     * The fieldNameOrIdent parameter can be either a field name (without directionality prefix),
+     * or a field identifier (which includes the prefix)
+     * @param fieldNameOrIdent Field name or identifier
+     * @param value Value to set
+     */
+    public setValue(fieldNameOrIdent: string, value: any) {
+        const fieldNameAndDir = fieldNameAndDirection(fieldNameOrIdent);
+
+        if (!this._fieldNameToIdent.has(fieldNameAndDir.field)) {
+            return;
+        }
+
+        const fieldIdent = this._fieldNameToIdent.get(fieldNameAndDir.field);
+        this._fields.set(fieldIdent, value);
+
+        // Call the value callback
+        this._onSetValue(fieldNameAndDir.field, value);
+    }
+
+    /**
+     * Get the list of field IDENTIFIERS.
+     *
+     * This function is used to generate the list of keys to be sent over WS
+     */
+    public getFieldsAsIdents(): string[] {
+        const fieldIdents: string[] = [];
+        this._fields.forEach((value, key) => {
+            fieldIdents.push(key);
+        });
+
+        return fieldIdents;
+    }
+
+    /**
+     * Callback for when a value is set on a field
+     *
+     * This is meant to be overriden by subclasses if they want to have special case
+     * handling of specific fields
+     * @param fieldName
+     * @param value
+     */
+    protected _onSetValue(fieldName: string, value: any) {}
+}


### PR DESCRIPTION
This commit leverages the SimDevices event in node-wpilib-ws to provide
Robot level SimDevice support. This allows for `WPILibWSRobotBase`
subclasses to register SimDevices on themselves, and have the Endpoint
automatically query and set values as appropriate.

Each `SimDevice` consists of fields which will be registered with the
`SimDevice` at creation time. These fields specify the data that the
`SimDevice` will handle. These will also get mapped to the actual
strings that are used in the WebSocket protocol to ensure that data gets
to and from robot code.

Resolves #10 